### PR TITLE
Fix crash on mac with multiple monitors

### DIFF
--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -327,6 +327,7 @@ auto Video::hasMonitors() -> vector<Monitor> {
       auto displayID = [screenID unsignedIntValue];
       auto displayPort = CGDisplayIOServicePort(displayID);
       auto dictionary = IODisplayCreateInfoDictionary(displayPort, 0);
+      CFRetain(dictionary);
       if(auto names = (CFDictionaryRef)CFDictionaryGetValue(dictionary, CFSTR(kDisplayProductName))) {
         auto languageKeys = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
         CFDictionaryApplyFunction(names, MonitorKeyArrayCallback, (void*)languageKeys);


### PR DESCRIPTION
The release/retain count of dictionary is wrong. The crash is from over releasing it. The fix is to either add a retain or remove the release. The autoreleasepool will reclaim it either way. I figured adding the retain is more clear.