### PR TITLE
Sync resources for libretro port and add Android target

### DIFF
--- a/bsnes/GNUmakefile
+++ b/bsnes/GNUmakefile
@@ -20,6 +20,18 @@ endif
 nall.path := ../nall
 include $(nall.path)/GNUmakefile
 
+ifeq ($(platform),win)
+  override platform = windows
+else ifeq ($(platform),mingw)
+  override platform = windows
+else ifeq ($(platform),osx)
+  override platform = macos
+else ifeq ($(platform),unix)
+  override platform = linux
+else ifeq ($(platform),x)
+  override platform = linux
+endif
+
 ifeq ($(platform),windows)
   ifeq ($(binary),application)
     options += -luuid -lkernel32 -luser32 -lgdi32 -lcomctl32 -lcomdlg32 -lshell32

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -8,9 +8,9 @@ obj/libretro.o: target-libretro/libretro.cpp
 
 all: $(objects)
 ifeq ($(platform),linux)
-	$(strip $(compiler) -o out/bsnes_libretro.so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -Wl,-Bdynamic -lpthread -ldl -lgomp)
+	$(strip $(compiler) -o out/bsnes_hd_libretro.so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -Wl,-Bdynamic -lpthread -ldl -lgomp)
 else ifeq ($(platform),windows)
-	$(strip $(compiler) -o out/bsnes_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -static-libgcc -static-libstdc++ -Wl,-Bstatic -lws2_32 -lpthread -lgomp -Wl,-Bdynamic)
+	$(strip $(compiler) -o out/bsnes_hd_libretro.dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -static-libgcc -static-libstdc++ -Wl,-Bstatic -lws2_32 -lpthread -lgomp -Wl,-Bdynamic)
 else ifeq ($(platform),macos)
-	$(strip $(compiler) -o out/bsnes_libretro.dylib -shared $(objects) -lpthread -ldl)
+	$(strip $(compiler) -o out/bsnes_hd_libretro.dylib -shared $(objects) -lpthread -ldl)
 endif

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -438,7 +438,7 @@ RETRO_API unsigned retro_api_version()
 
 RETRO_API void retro_get_system_info(retro_system_info *info)
 {
-	info->library_name     = "bsnes";
+	info->library_name     = "bsnes HD";
 	info->library_version  = Emulator::Version;
 	info->need_fullpath    = false;
 	info->valid_extensions = "smc|sfc";

--- a/nall/cipher/chacha20.hpp
+++ b/nall/cipher/chacha20.hpp
@@ -102,8 +102,13 @@ struct HChaCha20 : protected ChaCha20 {
 //192-bit nonce; 64-bit x 64-byte (256GB) counter
 struct XChaCha20 : ChaCha20 {
   XChaCha20(uint256_t key, uint192_t nonce, uint64_t counter = 0):
+#if defined(PLATFORM_ANDROID)
+  ChaCha20(HChaCha20(key, static_cast<uint128_t>(nonce)).key(), nonce >> 128, counter) {
+  }
+#else
   ChaCha20(HChaCha20(key, nonce).key(), nonce >> 128, counter) {
   }
+#endif
 };
 
 }


### PR DESCRIPTION
These commits sync the Boards.bml with the version in the standalone port, and add an Android build target to the libretro port. The Android build required some small changes to nall in order to build, and are ifdef'd to avoid affecting anything else.