### PR TITLE
Shrink struct SuperFamicom::PPUFast::Pixel from 12 to 4 bytes

### DIFF
--- a/bsnes/sfc/ppu-fast/background.cpp
+++ b/bsnes/sfc/ppu-fast/background.cpp
@@ -10,7 +10,7 @@ auto PPU::Line::cacheBackground(PPU::IO::Background& bg) -> void {
 }
 
 //parallelized
-auto PPU::Line::renderBackground(PPU::IO::Background& self, uint source) -> void {
+auto PPU::Line::renderBackground(PPU::IO::Background& self, uint8 source) -> void {
   if(!self.aboveEnable && !self.belowEnable) return;
   if(self.tileMode == TileMode::Mode7) return renderMode7(self, source);
   if(self.tileMode == TileMode::Inactive) return;
@@ -46,8 +46,8 @@ auto PPU::Line::renderBackground(PPU::IO::Background& self, uint source) -> void
 
   uint mosaicCounter = 1;
   uint mosaicPalette = 0;
-  uint mosaicPriority = 0;
-  uint mosaicColor = 0;
+  uint8 mosaicPriority = 0;
+  uint16 mosaicColor = 0;
 
   int x = 0 - (hscroll & 7);
   while(x < width) {
@@ -83,7 +83,7 @@ auto PPU::Line::renderBackground(PPU::IO::Background& self, uint source) -> void
     uint tileNumber = getTile(self, hoffset, voffset);
     uint mirrorY = tileNumber & 0x8000 ? 7 : 0;
     uint mirrorX = tileNumber & 0x4000 ? 7 : 0;
-    uint tilePriority = self.priority[bool(tileNumber & 0x2000)];
+    uint8 tilePriority = self.priority[bool(tileNumber & 0x2000)];
     uint paletteNumber = tileNumber >> 10 & 7;
     uint paletteIndex = paletteBase + (paletteNumber << paletteShift) & 0xff;
 

--- a/bsnes/sfc/ppu-fast/line.cpp
+++ b/bsnes/sfc/ppu-fast/line.cpp
@@ -63,8 +63,8 @@ auto PPU::Line::render(bool fieldID) -> void {
   }
 
   bool hires = io.pseudoHires || io.bgMode == 5 || io.bgMode == 6;
-  auto aboveColor = cgram[0];
-  auto belowColor = hires ? cgram[0] : io.col.fixedColor;
+  uint16 aboveColor = cgram[0];
+  uint16 belowColor = hires ? cgram[0] : io.col.fixedColor;
   uint xa =  (hd || ss) && ppu.interlace() && field() ? 256 * scale * scale / 2 : 0;
   uint xb = !(hd || ss) ? 256 : ppu.interlace() && !field() ? 256 * scale * scale / 2 : 256 * scale * scale;
   for(uint x = xa; x < xb; x++) {
@@ -145,18 +145,18 @@ auto PPU::Line::directColor(uint paletteIndex, uint paletteColor) const -> uint1
        + (paletteColor << 7 & 0x6000) + (paletteIndex << 10 & 0x1000);  //B
 }
 
-auto PPU::Line::plotAbove(uint x, uint source, uint priority, uint color) -> void {
+auto PPU::Line::plotAbove(uint x, uint8 source, uint8 priority, uint16 color) -> void {
   if(ppu.hd()) return plotHD(above, x, source, priority, color, false, false);
   if(priority > above[x].priority) above[x] = {source, priority, color};
 }
 
-auto PPU::Line::plotBelow(uint x, uint source, uint priority, uint color) -> void {
+auto PPU::Line::plotBelow(uint x, uint8 source, uint8 priority, uint16 color) -> void {
   if(ppu.hd()) return plotHD(below, x, source, priority, color, false, false);
   if(priority > below[x].priority) below[x] = {source, priority, color};
 }
 
 //todo: name these variables more clearly ...
-auto PPU::Line::plotHD(Pixel* pixel, uint x, uint source, uint priority, uint color, bool hires, bool subpixel) -> void {
+auto PPU::Line::plotHD(Pixel* pixel, uint x, uint8 source, uint8 priority, uint16 color, bool hires, bool subpixel) -> void {
   auto scale = ppu.hdScale();
   int xss = hires && subpixel ? scale / 2 : 0;
   int ys = ppu.interlace() && field() ? scale / 2 : 0;

--- a/bsnes/sfc/ppu-fast/mode7.cpp
+++ b/bsnes/sfc/ppu-fast/mode7.cpp
@@ -1,4 +1,4 @@
-auto PPU::Line::renderMode7(PPU::IO::Background& self, uint source) -> void {
+auto PPU::Line::renderMode7(PPU::IO::Background& self, uint8 source) -> void {
   //HD mode 7 support
   if(!ppu.hdMosaic() || !self.mosaicEnable || !io.mosaicSize) {
     if(ppu.hdScale() > 1) return renderMode7HD(self, source);
@@ -18,8 +18,8 @@ auto PPU::Line::renderMode7(PPU::IO::Background& self, uint source) -> void {
 
   uint mosaicCounter = 1;
   uint mosaicPalette = 0;
-  uint mosaicPriority = 0;
-  uint mosaicColor = 0;
+  uint8 mosaicPriority = 0;
+  uint16 mosaicColor = 0;
 
   auto clip = [](int n) -> int { return n & 0x2000 ? (n | ~1023) : (n & 1023); };
   int originX = (a * clip(hoffset - hcenter) & ~63) + (b * clip(voffset - vcenter) & ~63) + (b * y & ~63) + (hcenter << 8);
@@ -42,7 +42,7 @@ auto PPU::Line::renderMode7(PPU::IO::Background& self, uint source) -> void {
     uint8 tile = io.mode7.repeat == 3 && outOfBounds ? 0 : ppu.vram[tileAddress] >> 0;
     uint8 palette = io.mode7.repeat == 2 && outOfBounds ? 0 : ppu.vram[tile << 6 | paletteAddress] >> 8;
 
-    uint priority;
+    uint8 priority;
     if(source == Source::BG1) {
       priority = self.priority[0];
     } else if(source == Source::BG2) {

--- a/bsnes/sfc/ppu-fast/mode7hd.cpp
+++ b/bsnes/sfc/ppu-fast/mode7hd.cpp
@@ -95,7 +95,7 @@ auto PPU::Line::cacheMode7HD() -> void {
   }
 }
 
-auto PPU::Line::renderMode7HD(PPU::IO::Background& self, uint source) -> void {
+auto PPU::Line::renderMode7HD(PPU::IO::Background& self, uint8 source) -> void {
   const bool extbg = source == Source::BG2;
   const uint scale = ppu.hdScale();
 
@@ -190,7 +190,7 @@ auto PPU::Line::renderMode7HD(PPU::IO::Background& self, uint source) -> void {
           uint tile    = io.mode7.repeat == 3 && ((pixelX | pixelY) & ~1023) ? 0 : (ppu.vram[(pixelY >> 3 & 127) * 128 + (pixelX >> 3 & 127)] & 0xff);
           uint palette = io.mode7.repeat == 2 && ((pixelX | pixelY) & ~1023) ? 0 : (ppu.vram[(((pixelY & 7) << 3) + (pixelX & 7)) + (tile << 6)] >> 8);
 
-          uint priority;
+          uint8 priority;
           if(!extbg) {
             priority = self.priority[0];
           } else {
@@ -199,7 +199,7 @@ auto PPU::Line::renderMode7HD(PPU::IO::Background& self, uint source) -> void {
           }
           if(!palette) continue;
 
-          uint color;
+          uint16 color;
           if(io.col.directColor && !extbg) {
             color = directColor(0, palette);
           } else {
@@ -237,8 +237,8 @@ auto PPU::Line::renderMode7HD(PPU::IO::Background& self, uint source) -> void {
           br += b >> 10 & 31;
         }
       }
-      uint aboveColor = ab / divisor << 0 | ag / divisor << 5 | ar / divisor << 10;
-      uint belowColor = bb / divisor << 0 | bg / divisor << 5 | br / divisor << 10;
+      uint16 aboveColor = ab / divisor << 0 | ag / divisor << 5 | ar / divisor << 10;
+      uint16 belowColor = bb / divisor << 0 | bg / divisor << 5 | br / divisor << 10;
       this->above[p] = {source, this->above[p * scale].priority, aboveColor};
       this->below[p] = {source, this->below[p * scale].priority, belowColor};
     }

--- a/bsnes/sfc/ppu-fast/object.cpp
+++ b/bsnes/sfc/ppu-fast/object.cpp
@@ -117,7 +117,7 @@ auto PPU::Line::renderObject(PPU::IO::Object& self) -> void {
 
   for(uint x : range(256)) {
     if(!priority[x]) continue;
-    uint source = palette[x] < 192 ? Source::OBJ1 : Source::OBJ2;
+    uint8 source = palette[x] < 192 ? Source::OBJ1 : Source::OBJ2;
     if(self.aboveEnable && !windowAbove[x]) plotAbove(x, source, priority[x], cgram[palette[x]]);
     if(self.belowEnable && !windowBelow[x]) plotBelow(x, source, priority[x], cgram[palette[x]]);
   }

--- a/bsnes/sfc/ppu-fast/ppu.hpp
+++ b/bsnes/sfc/ppu-fast/ppu.hpp
@@ -39,7 +39,7 @@ struct PPU : PPUcounter {
   auto serialize(serializer&) -> void;
 
 public:
-  struct Source { enum : uint { BG1, BG2, BG3, BG4, OBJ1, OBJ2, COL }; };
+  struct Source { enum : uint8 { BG1, BG2, BG3, BG4, OBJ1, OBJ2, COL }; };
   struct TileMode { enum : uint { BPP2, BPP4, BPP8, Mode7, Inactive }; };
   struct ScreenMode { enum : uint { Above, Below }; };
 
@@ -239,9 +239,9 @@ public:
   };
 
   struct Pixel {
-    uint source;
-    uint priority;
-    uint color;
+    uint8 source;
+    uint8 priority;
+    uint16 color;
   };
 
   //io.cpp
@@ -290,21 +290,21 @@ public:
     auto pixel(uint x, Pixel above, Pixel below) const -> uint16;
     auto blend(uint x, uint y, bool halve) const -> uint16;
     alwaysinline auto directColor(uint paletteIndex, uint paletteColor) const -> uint16;
-    alwaysinline auto plotAbove(uint x, uint source, uint priority, uint color) -> void;
-    alwaysinline auto plotBelow(uint x, uint source, uint priority, uint color) -> void;
-    alwaysinline auto plotHD(Pixel*, uint x, uint source, uint priority, uint color, bool hires, bool subpixel) -> void;
+    alwaysinline auto plotAbove(uint x, uint8 source, uint8 priority, uint16 color) -> void;
+    alwaysinline auto plotBelow(uint x, uint8 source, uint8 priority, uint16 color) -> void;
+    alwaysinline auto plotHD(Pixel*, uint x, uint8 source, uint8 priority, uint16 color, bool hires, bool subpixel) -> void;
 
     //background.cpp
     auto cacheBackground(PPU::IO::Background&) -> void;
-    auto renderBackground(PPU::IO::Background&, uint source) -> void;
+    auto renderBackground(PPU::IO::Background&, uint8 source) -> void;
     auto getTile(PPU::IO::Background&, uint hoffset, uint voffset) -> uint;
 
     //mode7.cpp
-    auto renderMode7(PPU::IO::Background&, uint source) -> void;
+    auto renderMode7(PPU::IO::Background&, uint8 source) -> void;
 
     //mode7hd.cpp
     static auto cacheMode7HD() -> void;
-    auto renderMode7HD(PPU::IO::Background&, uint source) -> void;
+    auto renderMode7HD(PPU::IO::Background&, uint8 source) -> void;
     alwaysinline auto lerp(float pa, float va, float pb, float vb, float pr) -> float;
 
     //object.cpp


### PR DESCRIPTION
This gives approximately 3% speedup (118->122fps) on the F-Zero title screen, and allows simplifying (likely with an associated speed boost) #131 and other future SIMD code.