### PR TITLE
ruby/CGL: explicitly set current OpenGL context

### DIFF
--- a/ruby/video/cgl.cpp
+++ b/ruby/video/cgl.cpp
@@ -145,6 +145,7 @@ private:
       [view setWantsBestResolutionOpenGLSurface:YES];
       [context addSubview:view];
       [openGLContext setView:view];
+      [openGLContext makeCurrentContext];
       [[view window] makeFirstResponder:view];
       [view lockFocus];
 


### PR DESCRIPTION
On builds made with Xcode 11+ the current OpenGL context wasn't being properly configured anymore, resulting in shader compilation errors and a red screen.

Explicitly calling `makeCurrentContext` fixes this.

Fixes #234.