### PR TITLE
Fix "make clean" in mingw

### DIFF
--- a/bsnes/GNUmakefile
+++ b/bsnes/GNUmakefile
@@ -59,6 +59,9 @@ ui := target-$(target)
 include $(ui)/GNUmakefile
 -include obj/*.d
 
+
+delete = $(info Deleting $1 ...) @rm -f $1
+
 clean:
 	$(call delete,obj/*)
 	$(call delete,out/*)


### PR DESCRIPTION
Adds the definition for "delete". Without it mingw will always return "mingw32-make: 'clean' is up to date.".