### PR TITLE
Fix "make clean" in mingw (alternative solution)

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -34,15 +34,15 @@ ifeq ($(platform),)
   else
     $(error unknown platform, please specify manually.)
   endif
+endif
 
-  # common commands
-  ifeq ($(uname),)
-    delete  = $(info Deleting $1 ...) @del /q $(subst /,\,$1)
-    rdelete = $(info Deleting $1 ...) @del /s /q $(subst /,\,$1) && if exist $(subst /,\,$1) (rmdir /s /q $(subst /,\,$1))
-  else
-    delete  = $(info Deleting $1 ...) @rm -f $1
-    rdelete = $(info Deleting $1 ...) @rm -rf $1
-  endif
+# common commands
+ifneq ($(shell cd),)
+  delete  = $(info Deleting $1 ...) @del /q $(subst /,\,$1)
+  rdelete = $(info Deleting $1 ...) @del /s /q $(subst /,\,$1) && if exist $(subst /,\,$1) (rmdir /s /q $(subst /,\,$1))
+else
+  delete  = $(info Deleting $1 ...) @rm -f $1
+  rdelete = $(info Deleting $1 ...) @rm -rf $1
 endif
 
 compiler.c      = $(compiler) -x c -std=c11

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -37,7 +37,7 @@ ifeq ($(platform),)
 endif
 
 # common commands
-ifneq ($(shell cd),)
+ifeq ($(shell echo ^^),^)
   delete  = $(info Deleting $1 ...) @del /q $(subst /,\,$1)
   rdelete = $(info Deleting $1 ...) @del /s /q $(subst /,\,$1) && if exist $(subst /,\,$1) (rmdir /s /q $(subst /,\,$1))
 else


### PR DESCRIPTION
Fixes the definition for "delete". Without it mingw will always return "mingw32-make: 'clean' is up to date.".

An alternative to #281. I believe it'll do the right thing on real Unix-likes (tested), mingw32-make without msys or other Unix tools (tested), msys/git bash (not tested), and cygwin (not tested).

However, note that del does not treat dotfiles as hidden, so this will delete bsnes/obj/.gitignore.