### PR TITLE
[Libretro] Nintendo Switch Port

### DIFF
--- a/bsnes/emulator/emulator.hpp
+++ b/bsnes/emulator/emulator.hpp
@@ -6,7 +6,9 @@
 #include <nall/adaptive-array.hpp>
 #include <nall/any.hpp>
 #include <nall/chrono.hpp>
+#ifndef PLATFORM_HORIZON
 #include <nall/dl.hpp>
+#endif // PLATFORM_HORIZON
 #include <nall/endian.hpp>
 #include <nall/image.hpp>
 #include <nall/literals.hpp>

--- a/bsnes/gb/GNUmakefile
+++ b/bsnes/gb/GNUmakefile
@@ -1,5 +1,4 @@
 flags += -DGB_INTERNAL -DDISABLE_DEBUGGER -D_GNU_SOURCE -Wno-multichar
-options += -I../sameboy
 
 objects += gb-apu gb-camera gb-display gb-gb gb-joypad gb-mbc
 objects += gb-memory gb-printer gb-random gb-rewind gb-save_state gb-sgb

--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -9,6 +9,10 @@ ifeq ($(platform), ios-arm64)
 else ifeq ($(platform), tvos-arm64)
 	flags += -fPIC -mtvos-version-min=11.0 -Wno-error=implicit-function-declaration -DHAVE_POSIX_MEMALIGN
 	options += -dynamiclib
+else ifeq ($(platform), libnx)
+	flags += -march=armv8-a+crc -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -DHAVE_POSIX_MEMALIGN
+	flags += -O2 -ftree-vectorize -ffast-math -funsafe-math-optimizations -fPIE -I$(PORTLIBS)/include/ -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec
+	flags += -D__SWITCH__=1 -D__aarch64__=1 -DSWITCH -DHAVE_LIBNX
 endif
 
 objects := libretro $(objects)
@@ -21,6 +25,8 @@ ifeq ($(platform),linux)
 	$(strip $(compiler) -o out/$(name).so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
 else ifeq ($(platform),windows)
 	$(strip $(compiler) -o out/$(name).dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
+else ifeq ($(platform),libnx)
+	$(strip $(AR) rcs out/$(name).a $(objects))
 else ifeq ($(platform),macos)
 	$(strip $(compiler) -o out/$(name).dylib -shared $(objects) $(options))
 else ifeq ($(platform), ios-arm64)

--- a/libco/settings.h
+++ b/libco/settings.h
@@ -30,6 +30,15 @@
   #define section(name) __declspec(allocate("." #name))
 #elif defined(__APPLE__)
   #define section(name) __attribute__((section("__TEXT,__" #name)))
+#elif defined(__SWITCH__)
+  /*
+    This is basically the same as the last case, however the "#" suffix will create a secondary .text section.
+    Because of that, the toolchain will treat the section as non-executable. This might be related to the linker scripts
+    used for libnx homebrew. The reason that this is a seperate ifdef, is purely to silence a cosmetic warn
+    about ignoring the +w attribute on .text which would happen on other platforms under some conditions (said warning is by design 
+    when data is being merged like this into .text).
+  */
+  #define section(name) __attribute__((section("." #name)))
 #else
   #define section(name) __attribute__((section("." #name "#")))
 #endif

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -68,6 +68,14 @@ ifeq ($(compiler),)
     compiler := clang++
   else ifeq ($(platform),linux)
     compiler := g++
+  else ifeq ($(platform),libnx)
+    include $(DEVKITPRO)/libnx/switch_rules
+    PORTLIBS := $(PORTLIBS_PATH)/switch
+    PATH := $(PORTLIBS)/bin:$(PATH)
+    LIBNX ?= $(DEVKITPRO)/libnx
+    compiler = $(CC) -std=gnu11
+    compiler.cpp = $(CXX) -std=gnu++17
+    openmp = false
   else ifeq ($(platform),bsd)
     compiler := g++8
   else
@@ -128,6 +136,11 @@ endif
 # linux settings
 ifeq ($(platform),linux)
   options += -ldl
+endif
+
+# libnx settings
+ifeq ($(platform),libnx)
+  flags += -D__SWITCH__=1 -DSWITCH -DHAVE_LIBNX
 endif
 
 # bsd settings

--- a/nall/file-map.hpp
+++ b/nall/file-map.hpp
@@ -10,7 +10,11 @@
 #else
   #include <fcntl.h>
   #include <unistd.h>
+#if defined(PLATFORM_HORIZON)
+  #include <nall/horizon/mman.hpp>
+#else
   #include <sys/mman.h>
+#endif // PLATFORM_HORIZON
   #include <sys/stat.h>
   #include <sys/types.h>
 #endif

--- a/nall/horizon/mman.hpp
+++ b/nall/horizon/mman.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdlib.h>
+
+// Workaround since we don't support file mappings on Horizon, but this is currently not functional.
+// To make it work, the file could be read when the file_map is opened
+#define PROT_READ 0b001
+#define PROT_WRITE 0b010
+#define PROT_EXEC 0b100
+#define MAP_PRIVATE 2
+#define MAP_FIXED 0x10
+#define MAP_ANONYMOUS 0x20
+#define MAP_FAILED ((void *)-1)
+#define MAP_SHARED 0
+
+static inline void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset)
+{
+  return malloc(len);
+}
+
+static inline int mprotect(void *addr, size_t len, int prot)
+{
+  return 0;
+}
+
+static inline int munmap(void *addr, size_t len)
+{
+  free(addr);
+  return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -4,7 +4,7 @@ namespace nall {
   using uint = unsigned;
 
   enum class Compiler : uint { Clang, GCC, Microsoft, Unknown };
-  enum class Platform : uint { Windows, MacOS, Linux, BSD, Android, Unknown };
+  enum class Platform : uint { Windows, MacOS, Linux, BSD, Android, Horizon, Unknown };
   enum class API : uint { Windows, Posix, Unknown };
   enum class DisplayServer : uint { Windows, Quartz, Xorg, Unknown };
   enum class Architecture : uint { x86, amd64, ARM32, ARM64, PPC32, PPC64, Unknown };
@@ -89,6 +89,13 @@ namespace nall {
   constexpr auto platform() -> Platform { return Platform::Android; }
   constexpr auto api() -> API { return API::Posix; }
   constexpr auto display() -> DisplayServer { return DisplayServer::Unknown; }
+#elif defined(__SWITCH__)
+  #define PLATFORM_HORIZON
+  #define API_POSIX
+  #define DISPLAY_UNKNOWN
+  constexpr auto platform() -> Platform { return Platform::Horizon; }
+  constexpr auto api() -> API { return API::Posix; }
+  constexpr auto display() -> DisplayServer { return DisplayServer::Unknown; }
 #elif defined(linux) || defined(__linux__)
   #define PLATFORM_LINUX
   #define API_POSIX
@@ -157,7 +164,7 @@ namespace nall {
 
 namespace nall {
 
-#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64)
+#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(__aarch64__)
   #define ENDIAN_LSB
   constexpr auto endian() -> Endian { return Endian::LSB; }
 #elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__powerpc__) || defined(_M_PPC)

--- a/nall/nall.hpp
+++ b/nall/nall.hpp
@@ -24,7 +24,9 @@
 #include <nall/bit.hpp>
 #include <nall/chrono.hpp>
 #include <nall/directory.hpp>
+#if !defined(PLATFORM_HORIZON)
 #include <nall/dl.hpp>
+#endif // PLATFORM_HORIZON
 #include <nall/endian.hpp>
 #include <nall/file.hpp>
 #include <nall/file-buffer.hpp>

--- a/nall/platform.hpp
+++ b/nall/platform.hpp
@@ -45,7 +45,9 @@ namespace Math {
 #include <sys/stat.h>
 
 #if !defined(PLATFORM_WINDOWS)
+#if !defined(PLATFORM_HORIZON)
   #include <dlfcn.h>
+#endif // PLATFORM_HORIZON
   #include <unistd.h>
   #include <pwd.h>
   #include <grp.h>

--- a/nall/service.hpp
+++ b/nall/service.hpp
@@ -4,10 +4,11 @@
 
 #include <nall/shared-memory.hpp>
 
-#if defined(API_POSIX)
+#if defined(API_POSIX) && !defined(PLATFORM_HORIZON)
   #include <nall/posix/service.hpp>
 #endif
 
-#if defined(API_WINDOWS)
+// For Horizon we re-use the Windows stub
+#if defined(API_WINDOWS) || defined(PLATFORM_HORIZON)
   #include <nall/windows/service.hpp>
 #endif

--- a/nall/shared-memory.hpp
+++ b/nall/shared-memory.hpp
@@ -3,10 +3,11 @@
 #include <nall/memory.hpp>
 #include <nall/string.hpp>
 
-#if defined(API_POSIX)
+#if defined(API_POSIX) && !defined(PLATFORM_HORIZON)
   #include <nall/posix/shared-memory.hpp>
 #endif
 
-#if defined(API_WINDOWS)
+// For Horizon we re-use the Windows stub
+#if defined(API_WINDOWS) || defined(PLATFORM_HORIZON)
   #include <nall/windows/shared-memory.hpp>
 #endif


### PR DESCRIPTION
- Includes some minor cleanups and AArch64 specific changes
- OpenMP needs toolchain changes and is currently disabled, but already got a working PoC
- SGB was also confirmed working

`make -C bsnes platform=libnx target=libretro local=false -j12`