### PR TITLE
ICD: move multi-player select from packet handler into SNES-side IO

### DIFF
--- a/bsnes/sfc/coprocessor/icd/interface.cpp
+++ b/bsnes/sfc/coprocessor/icd/interface.cpp
@@ -88,14 +88,6 @@ auto ICD::joypWrite(bool p14, bool p15) -> void {
 
   if(packetLock == 1) {
     if(p14 == 0 && p15 == 1) {
-      if((joypPacket[0] >> 3) == 0x11) {
-        mltReq = joypPacket[1] & 3;
-        if(mltReq == 0) joypID &= 0;  //1-player mode
-        if(mltReq == 1) joypID &= 1;  //2-player mode
-        if(mltReq == 2) joypID &= 3;  //4-player mode (unverified; but the most likely behavior)
-        if(mltReq == 3) joypID &= 3;  //4-player mode
-      }
-
       if(packetSize < 64) packet[packetSize++] = joypPacket;
       packetLock = 0;
       pulseLock = 1;

--- a/bsnes/sfc/coprocessor/icd/io.cpp
+++ b/bsnes/sfc/coprocessor/icd/io.cpp
@@ -55,6 +55,13 @@ auto ICD::writeIO(uint addr, uint8 data) -> void {
     if((r6003 & 0x80) == 0x00 && (data & 0x80) == 0x80) {
       power(true);  //soft reset
     }
+
+    mltReq = (data >> 4) & 3;
+    if(mltReq == 0) joypID &= 0;  //1-player mode
+    if(mltReq == 1) joypID &= 1;  //2-player mode
+    if(mltReq == 2) joypID &= 3;  //4-player mode (unverified; but the most likely behavior)
+    if(mltReq == 3) joypID &= 3;  //4-player mode
+
     auto frequency = clockFrequency();
     switch(data & 3) {
     case 0: this->frequency = frequency / 4; break;  //fast (glitchy, even on real hardware)


### PR DESCRIPTION
re: #290. Passes the test ROM in that issue, doesn't seem to cause any issues with actual games that use MLT_REQ for SGB detection, etc.